### PR TITLE
Add script to sync reference repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+reference-repos/

--- a/manifests/references.yaml
+++ b/manifests/references.yaml
@@ -1,0 +1,26 @@
+repos:
+  - name: codex
+    url: https://github.com/openai/codex.git
+    branch: main
+    sparse: []
+  - name: codex-universal
+    url: https://github.com/openai/codex-universal.git
+    branch: main
+    # Includes individual files; script supports file-level sparse patterns.
+    sparse: ["README.md","Dockerfile"]
+  - name: harmony
+    url: https://github.com/openai/harmony.git
+    branch: main
+    sparse: ["docs","python/openai_harmony","src"]
+  - name: gpt-oss
+    url: https://github.com/openai/gpt-oss.git
+    branch: main
+    sparse: []
+  - name: llama.cpp
+    url: https://github.com/ggml-org/llama.cpp.git
+    branch: master
+    sparse: ["docs","examples","server"]
+  - name: openai-cookbook
+    url: https://github.com/openai/openai-cookbook.git
+    branch: main
+    sparse: ["articles","examples"]

--- a/scripts/sync-refs.sh
+++ b/scripts/sync-refs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: bash scripts/sync-refs.sh [DEST_DIR] [MANIFEST]
+DEST="${1:-reference-repos}"
+MANIFEST="${2:-manifests/references.yaml}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing $1"; exit 1; }; }
+need git
+need yq
+
+mkdir -p "$DEST"
+count=$(yq '.repos | length' "$MANIFEST")
+
+for ((i=0; i<count; i++)); do
+  name=$(yq -r ".repos[$i].name" "$MANIFEST")
+  url=$(yq -r ".repos[$i].url" "$MANIFEST")
+  branch=$(yq -r ".repos[$i].branch" "$MANIFEST")
+  mapfile -t sparse < <(yq -r ".repos[$i].sparse[]" "$MANIFEST" 2>/dev/null || true)
+
+  dest="$DEST/$name"
+
+  if [ -d "$dest/.git" ]; then
+    echo "[refs] updating $name..."
+    git -C "$dest" fetch --prune --depth 1 origin "$branch"
+    git -C "$dest" checkout -qf FETCH_HEAD
+  else
+    echo "[refs] cloning $name..."
+    git clone --depth 1 --no-tags --single-branch -b "$branch" "$url" "$dest"
+  fi
+
+  if [ "${#sparse[@]}" -gt 0 ]; then
+    # If any entry probably refers to a file (heuristic: contains a dot and doesn't end with /),
+    # switch to non-cone mode. Cone mode only supports directories.
+    use_nocone=0
+    for p in "${sparse[@]}"; do
+      if [[ "$p" != */ && "$p" == *.* ]]; then
+        use_nocone=1
+        break
+      fi
+    done
+
+    if [[ $use_nocone -eq 1 ]]; then
+      git -C "$dest" sparse-checkout init --no-cone
+      git -C "$dest" sparse-checkout set "${sparse[@]}"
+    else
+      git -C "$dest" sparse-checkout init --cone
+      git -C "$dest" sparse-checkout set "${sparse[@]}"
+    fi
+  fi
+done
+
+echo "[refs] done"


### PR DESCRIPTION
## Summary
- ignore cloned reference repositories
- list reference repos with sparse paths and file-level entries
- add sync-refs script that supports directory and file sparse checkouts

## Testing
- `bash -n scripts/sync-refs.sh`
- `bash scripts/sync-refs.sh "$tmpdir" manifests/references.yaml`
- `test -d "$tmpdir/codex"`
- `test -d "$tmpdir/llama.cpp"`
- `test -f "$tmpdir/codex-universal/README.md"`


------
https://chatgpt.com/codex/tasks/task_b_68b13fddd09c832e9c71e62e885b8257