### PR TITLE
docs(infra): document Codex env + add versioned setup/maintenance scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+This repo is the shared workspace for local and cloud agents. Heavy reference repos are hydrated into `reference-repos/` at container start/resume; they are not committed to git.
+
+## Layout
+- `reference-repos/` – up-to-date clones of external repos (gitignored)
+- `manifests/references.yaml` – list of repos/branches/sparse paths to hydrate
+- `scripts/sync-refs.sh` – clones/updates refs (shallow, sparse-aware)
+- `scripts/container-setup.sh` – container Setup hook (versioned here)
+- `scripts/container-maintenance.sh` – container Maintenance hook (versioned here)
+- `docs/codex-environment.md` – detailed environment notes
+
+## Codex Cloud environment (summary)
+- Image: `openai/codex-universal` (Ubuntu 24.04; Python/Node/Rust/Go/Ruby/etc. preinstalled)
+- Internet: enabled
+- Env vars: expects `OPENAI_API_KEY` at runtime (do **not** commit secrets)
+- Container caching: on
+- Setup script: `bash scripts/container-setup.sh`
+- Maintenance script: `bash scripts/container-maintenance.sh`
+
+## Local refresh
+- Manually: `bash scripts/sync-refs.sh reference-repos manifests/references.yaml`
+
+## Don’ts
+- Don’t commit the contents of `reference-repos/`.
+- Don’t store API keys in the repo. Use environment variables or your shell.
+
+---

--- a/docs/codex-environment.md
+++ b/docs/codex-environment.md
@@ -1,0 +1,68 @@
+# Codex Cloud Environment
+
+## Image and toolchains
+- Image: `openai/codex-universal`
+- Toolchains (current config): Python 3.12, Node 20, Ruby 3.4.4, Rust 1.89.0, Go 1.24.3, Bun 1.2.14, PHP 8.4, Java 21, Swift 6.1
+
+## Environment variables
+- `OPENAI_API_KEY`: required for any OpenAI-compatible clients run inside the container.
+
+## Setup script (runs on cold container after repo clone)
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[setup] start"
+if ! command -v git >/dev/null 2>&1; then apt-get update -y && apt-get install -y git; fi
+if ! command -v curl >/dev/null 2>&1; then apt-get update -y && apt-get install -y curl; fi
+if ! command -v yq >/dev/null 2>&1; then
+  curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+fi
+if [ -f "manifests/references.yaml" ] && [ -f "scripts/sync-refs.sh" ]; then
+  bash scripts/sync-refs.sh "reference-repos" "manifests/references.yaml"
+else
+  echo "[setup] references manifest or sync script missing; skipping hydration"
+fi
+# Optional dep warming (noop if no lockfiles present)
+if [ -f package.json ]; then
+  (command -v pnpm >/dev/null && pnpm install --frozen-lockfile || true) || \
+  (command -v yarn >/dev/null && yarn install --frozen-lockfile || true) || \
+  (command -v npm  >/dev/null && npm ci || npm install || true)
+fi
+if [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  (command -v uv >/dev/null && uv pip install -r requirements.txt || true) || \
+  (command -v poetry >/dev/null && poetry install --no-interaction || true) || \
+  (command -v pip >/dev/null && pip install -r requirements.txt || true)
+fi
+if [ -f Cargo.toml ]; then cargo fetch || true; fi
+if [ -f go.mod ]; then go mod download || true; fi
+echo "[setup] done"
+```
+
+## Maintenance script (runs on cached container resume)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[maintenance] start"
+if ! command -v yq >/dev/null 2>&1; then
+  curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+fi
+if [ -f "manifests/references.yaml" ] && [ -f "scripts/sync-refs.sh" ]; then
+  bash scripts/sync-refs.sh "reference-repos" "manifests/references.yaml"
+else
+  echo "[maintenance] references manifest or sync script missing; skipping hydration"
+fi
+if [ -f package.json ]; then
+  (command -v pnpm >/dev/null && pnpm install --frozen-lockfile || true) || \
+  (command -v yarn >/dev/null && yarn install --frozen-lockfile || true) || \
+  (command -v npm  >/dev/null && npm ci || true)
+fi
+if [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  (command -v uv >/dev/null && uv pip install -r requirements.txt || true) || \
+  (command -v poetry >/dev/null && poetry install --no-interaction || true) || \
+  (command -v pip >/dev/null && pip install -r requirements.txt || true)
+fi
+if [ -f Cargo.toml ]; then cargo fetch || true; fi
+if [ -f go.mod ]; then go mod download || true; fi
+echo "[maintenance] done"
+```

--- a/scripts/container-maintenance.sh
+++ b/scripts/container-maintenance.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[maintenance] start"
+if ! command -v yq >/dev/null 2>&1; then
+  curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+fi
+if [ -f "manifests/references.yaml" ] && [ -f "scripts/sync-refs.sh" ]; then
+  bash scripts/sync-refs.sh "reference-repos" "manifests/references.yaml"
+else
+  echo "[maintenance] references manifest or sync script missing; skipping hydration"
+fi
+if [ -f package.json ]; then
+  (command -v pnpm >/dev/null && pnpm install --frozen-lockfile || true) || \
+  (command -v yarn >/dev/null && yarn install --frozen-lockfile || true) || \
+  (command -v npm  >/dev/null && npm ci || true)
+fi
+if [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  (command -v uv >/dev/null && uv pip install -r requirements.txt || true) || \
+  (command -v poetry >/dev/null && poetry install --no-interaction || true) || \
+  (command -v pip >/dev/null && pip install -r requirements.txt || true)
+fi
+if [ -f Cargo.toml ]; then cargo fetch || true; fi
+if [ -f go.mod ]; then go mod download || true; fi
+echo "[maintenance] done"

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[setup] start"
+if ! command -v git >/dev/null 2>&1; then apt-get update -y && apt-get install -y git; fi
+if ! command -v curl >/dev/null 2>&1; then apt-get update -y && apt-get install -y curl; fi
+if ! command -v yq >/dev/null 2>&1; then
+  curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+fi
+if [ -f "manifests/references.yaml" ] && [ -f "scripts/sync-refs.sh" ]; then
+  bash scripts/sync-refs.sh "reference-repos" "manifests/references.yaml"
+else
+  echo "[setup] references manifest or sync script missing; skipping hydration"
+fi
+
+# Optional dep warming (noop if no lockfiles present)
+
+if [ -f package.json ]; then
+  (command -v pnpm >/dev/null && pnpm install --frozen-lockfile || true) || \
+  (command -v yarn >/dev/null && yarn install --frozen-lockfile || true) || \
+  (command -v npm  >/dev/null && npm ci || npm install || true)
+fi
+if [ -f pyproject.toml ] || [ -f requirements.txt ]; then
+  (command -v uv >/dev/null && uv pip install -r requirements.txt || true) || \
+  (command -v poetry >/dev/null && poetry install --no-interaction || true) || \
+  (command -v pip >/dev/null && pip install -r requirements.txt || true)
+fi
+if [ -f Cargo.toml ]; then cargo fetch || true; fi
+if [ -f go.mod ]; then go mod download || true; fi
+echo "[setup] done"


### PR DESCRIPTION
## Summary
- document Codex Cloud environment with setup and maintenance hooks
- version setup/maintenance scripts in repo and hydrate references from manifest
- fix setup-script code fence in environment docs

## Testing
- `command -v yq >/dev/null 2>&1 || (curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq)`
- `bash -n scripts/sync-refs.sh`
- `bash -n scripts/container-setup.sh`
- `bash -n scripts/container-maintenance.sh`
- `tmpdir="ref-test-$$"; mkdir -p "$tmpdir"; bash scripts/sync-refs.sh "$tmpdir" manifests/references.yaml`
- `test -d "$tmpdir/codex"`
- `test -d "$tmpdir/llama.cpp"`
- `test -f "$tmpdir/codex-universal/README.md"`


------
https://chatgpt.com/codex/tasks/task_b_68b1473870fc832ea0e287eb6f2ae85c