### PR TITLE
chore(sync): partial clones + normalized sparse paths to reduce noise and bandwidth

### DIFF
--- a/manifests/references.yaml
+++ b/manifests/references.yaml
@@ -7,7 +7,7 @@ repos:
     url: https://github.com/openai/codex-universal.git
     branch: main
     # Includes individual files; script supports file-level sparse patterns.
-    sparse: ["README.md","Dockerfile"]
+    sparse: ["/README.md","/Dockerfile"]
   - name: harmony
     url: https://github.com/openai/harmony.git
     branch: main


### PR DESCRIPTION
## Summary
- normalize codex-universal sparse paths with leading slash
- use `--filter=blob:none` for leaner partial clones in sync script
- normalize sparse entries during sync and strip leading slash in cone mode

## Testing
- `bash -n scripts/sync-refs.sh`
- `tmpdir="ref-test-small-5335"; bash scripts/sync-refs.sh "$tmpdir" /tmp/test_manifest.yaml | tee /tmp/sync.log`
- `grep -n "pass a leading slash" /tmp/sync.log || echo 'no warnings'`


------
https://chatgpt.com/codex/tasks/task_b_68b14dc6e3e4832ea7245417e8aae718