### PR TITLE
feat: add agents.md and openai-agents-python reference repos

### DIFF
--- a/manifests/references.yaml
+++ b/manifests/references.yaml
@@ -68,3 +68,11 @@ repos:
     url: https://github.com/unslothai/unsloth.git
     branch: main
     sparse: []
+  - name: agents.md
+    url: https://github.com/openai/agents.md.git
+    branch: main
+    sparse: []
+  - name: openai-agents-python
+    url: https://github.com/openai/openai-agents-python.git
+    branch: main
+    sparse: []


### PR DESCRIPTION
## Summary
- add `openai/agents.md` to hydrated reference repo manifest
- add `openai/openai-agents-python` to hydrated reference repo manifest

## Testing
- `bash scripts/sync-refs.sh reference-repos manifests/references.yaml`


------
https://chatgpt.com/codex/tasks/task_b_68b25d7a0104832e9b28b9479c62553b