### PR TITLE
Install Codex CLI and configure auth in container scripts

### DIFF
--- a/scripts/container-maintenance.sh
+++ b/scripts/container-maintenance.sh
@@ -9,6 +9,11 @@ if [ -f "manifests/references.yaml" ] && [ -f "scripts/sync-refs.sh" ]; then
 else
   echo "[maintenance] references manifest or sync script missing; skipping hydration"
 fi
+
+# Upgrade Codex CLI
+if command -v npm >/dev/null 2>&1; then
+  npm update -g @openai/codex >/dev/null 2>&1 || true
+fi
 if [ -f package.json ]; then
   (command -v pnpm >/dev/null && pnpm install --frozen-lockfile || true) || \
   (command -v yarn >/dev/null && yarn install --frozen-lockfile || true) || \

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -12,6 +12,29 @@ else
   echo "[setup] references manifest or sync script missing; skipping hydration"
 fi
 
+# Install Codex CLI and configure authentication
+if command -v npm >/dev/null 2>&1; then
+  npm install -g @openai/codex >/dev/null 2>&1 || true
+fi
+
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  CODEX_HOME="$HOME/.codex"
+  mkdir -p "$CODEX_HOME"
+  cat >"$CODEX_HOME/auth.json" <<EOF
+{"OPENAI_API_KEY":"$OPENAI_API_KEY"}
+EOF
+  cat >"$CODEX_HOME/config.toml" <<'EOF'
+model = "gpt-5-mini"
+model_reasoning_effort = "medium"
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+show_raw_agent_reasoning = true
+
+[sandbox_workspace_write]
+network_access = true
+EOF
+fi
+
 # Optional dep warming (noop if no lockfiles present)
 
 if [ -f package.json ]; then


### PR DESCRIPTION
## Summary
- install OpenAI Codex CLI during container setup and generate auth/config files targeting gpt-5-mini with network access and medium reasoning
- upgrade Codex CLI on container maintenance
- document updated setup and maintenance procedures

## Testing
- `bash scripts/container-setup.sh` *(fails: OPENAI_API_KEY placeholder caused unauthorized errors when Codex attempted to connect)*
- `bash scripts/container-maintenance.sh`
- `codex --version`
- `codex exec "what is 2+2?"` *(fails: 401 Unauthorized due to placeholder API key)*


------
https://chatgpt.com/codex/tasks/task_b_68b263afd7a8832eb40168477427e777