### PR TITLE
Add reference repo analysis report

### DIFF
--- a/docs/reference-repos-report.md
+++ b/docs/reference-repos-report.md
@@ -1,0 +1,174 @@
+# Reference Repository Landscape and Strategic Integration Plan
+
+## Introduction
+
+The agent ecosystem in this workspace is built around a simple proposition: every environment—Codex Cloud, Codex CLI, and a network of local GPT‑OSS servers—shares a common set of scripts, container images, and hydrated reference repositories. This shared substrate makes it possible for agents to collaborate across hardware boundaries while drawing from the same knowledge and tooling. To fully realize the potential of this approach we need a clear understanding of what each reference repository brings to the table and how the pieces combine into a resilient, creative, and ever‑expanding system.
+
+The following report surveys the entire set of hydrated references, relates them to the immediate and long‑term goals laid out for the project, and proposes concrete as well as speculative pathways for growth. It is organized into four main sections. First, we examine each repository to understand its capabilities. Next, we synthesize patterns across repositories that directly advance the near‑term goals: reliable setup, verified environment parity, and a baseline knowledge pipeline. The third section leaps into more ambitious territory, describing workflows that mesh GPT‑5, GPT‑OSS, and custom MCP servers into a distributed “second brain.” The final section captures future research directions and provocative ideas that could spin out of this platform.
+
+This document is intentionally comprehensive. The aim is not merely to summarize but to act as an evolving design record that future agents—whether running in Codex Cloud, on a homelab GPU cluster, or a Raspberry Pi—can consult to understand why these references exist and how to wield them together. Throughout, the emphasis is on using the repositories in service of three pillars: **knowledge management**, **unified workflows**, and **agent identity & collaboration**.
+
+## Repository Analyses
+
+### agents.md
+
+The `agents.md` repository defines the convention for providing structured guidance to coding agents through an `AGENTS.md` file. By treating instructions as first‑class citizens, it encourages a predictable communication channel between humans and AI coders. For this workspace the implication is twofold. First, every participating project can publish expectations—testing commands, style rules, or environment notes—in a machine‑readable format. Second, the agents themselves can traverse the tree of `AGENTS.md` files to reason about context‑specific constraints. As the system scales to include multiple agent identities operating across GitHub accounts, `agents.md` becomes a governance layer: agents can leave instructions for one another, gradually evolving a codified project culture.
+
+### codex
+
+The `codex` repository houses the source for the Codex CLI, a local coding agent packaged as an npm module or Homebrew formula. In the current setup script the CLI is installed and primed to talk to the GPT‑5 mini model with medium reasoning. Several features make Codex CLI especially suited for the goals here:
+
+1. **Portability** – It runs on macOS, Linux, and via binaries on other platforms, which means the same CLI can execute within Codex Cloud and on remote machines like the homelab or a Pi.
+2. **Toolability** – Codex’s internal agent framework allows extensions and scripted behaviors, making it the ideal orchestrator for spinning up MCP connectors, synchronizing reference repos, or handing off tasks to other agents.
+3. **Cognitive parity** – By pointing Codex CLI at the same OPENAI_API_KEY used in Codex Cloud, we ensure that both environments produce comparable reasoning, enabling reliable cross‑validation of outputs.
+
+Long term, Codex CLI can serve as the “nerve fiber” connecting distributed agents: it can invoke GPT‑OSS endpoints when operating offline, trigger local inference through `llama.cpp`, or batch tasks for cloud execution.
+
+### codex‑universal
+
+`codex-universal` provides the Dockerfile used to generate the base image behind Codex Cloud. The repository exists so that developers can replicate an approximation of the Codex runtime locally, ensuring that setup and maintenance scripts behave identically regardless of where they are run. In practice this image is a convergence point for multi‑language toolchains—Python 3.12, Node 20, Rust 1.87, Go 1.23, Swift 6.1, Ruby 3.4, PHP 8.4—allowing agents to switch languages seamlessly. For the project’s goals this consistency is vital: it means a workflow constructed on a laptop will work inside Codex Cloud without “it works on my machine” bugs.
+
+A strategic idea is to maintain derivative images for specialized hardware. For example, an `codex-universal-cuda` variant could bake in GPU dependencies, enabling the homelab to run the same scripts with full CUDA support while still aligning with the canonical environment.
+
+### gpt‑oss
+
+The `gpt-oss` repository delivers OpenAI’s open‑weight models in two sizes—120B for high‑end inference and 20B for local or specialized tasks. Both models are trained on the harmony response format, making them first‑class citizens in this ecosystem. Their Apache 2.0 license removes the usual friction associated with commercial usage of open models, which is crucial for experimentation across cloud and homelab settings.
+
+Several aspects of `gpt-oss` align with the project’s ambitions:
+
+- **Local autonomy** – With the 20B model fitting on a single high‑VRAM GPU, agents can continue operating even when disconnected from OpenAI’s hosted APIs. This is key for the WireGuard‑connected homelab where agents may switch to a local fallback endpoint.
+- **Format coherence** – By adhering to the harmony structure, outputs from GPT‑OSS models can be parsed and cross‑referenced in the same manner as responses from GPT‑5, simplifying orchestration.
+- **Extensibility** – The repository includes reference implementations in PyTorch and Triton, along with tools for the Harmony format and a growing ecosystem of clients. This opens the door to fine‑tuning via `unsloth`, integration into `llama.cpp`, or embedding into multi‑agent chains with the `openai-agents-python` SDK.
+
+### harmony
+
+`harmony` defines the response format that governs GPT‑OSS models. It specifies how messages are structured, how chain‑of‑thought is isolated, and how tool calls are embedded. The format mimics OpenAI’s Responses API and extends it with channel routing and structured outputs. Within this workspace, Harmony is the glue that allows agents to collaborate regardless of whether the underlying model is GPT‑5 or GPT‑OSS. When Codex CLI speaks Harmony internally, an agent running on a homelab GPU using GPT‑OSS can hand off tasks to a Codex Cloud agent using GPT‑5 without lossy translation.
+
+From a knowledge management standpoint, Harmony enables richer metadata around agent interactions. A note in Obsidian could store not only the human‑visible summary of a paper but also the hidden “reasoning” channel produced during analysis, creating a provenance trail that future agents can audit.
+
+### llama.cpp
+
+`llama.cpp` is a versatile C/C++ inference engine optimized for running large language models on consumer‑grade hardware. It supports GGUF formats, offers server and library interfaces, and features multimodal capabilities. For this project, llama.cpp is the bridge between the open models in `gpt-oss` and the hardware in the homelab. By converting GPT‑OSS weights into GGUF and loading them through llama.cpp, agents can run high‑throughput inference locally without sacrificing the Harmony format.
+
+One imaginative direction is to use llama.cpp’s server mode as a drop‑in replacement for the OpenAI API during connectivity outages. Codex CLI could detect endpoint availability and automatically reroute requests to the local server, maintaining a seamless agent experience.
+
+### unsloth
+
+`unsloth` focuses on efficient fine‑tuning of open models, boasting speedups of up to 2× and VRAM savings as high as 80%. It supports GPT‑OSS, Gemma, Qwen, Llama, Mistral, and more, and offers one‑click Colab notebooks. This repository is a key enabler for personalization: agents can ingest domain‑specific corpora—such as the user’s own research notes—and fine‑tune a GPT‑OSS model that runs in the homelab.
+
+A practical workflow could automatically extract new content from Obsidian, package it as a fine‑tuning dataset, and trigger an unsloth job on the homelab. The resulting model snapshot would then be registered in a local model catalog, ready for deployment via llama.cpp or a Triton server. Over time, the system evolves into a personalized knowledge engine that retains the user’s voice and preferences.
+
+### openai‑agents‑python
+
+The `openai-agents-python` SDK provides a framework for constructing multi‑agent systems with concepts like agents, handoffs, guardrails, sessions, and tracing. Its provider‑agnostic design means that one agent in a workflow can call GPT‑5 while another consults a GPT‑OSS model or a custom MCP server. For the current project, this SDK is the orchestration layer that can tie together Codex CLI, local MCP servers, and the homelab endpoints.
+
+Imagine a workflow where an “ArXiv Curator” agent uses `mcp-simple-arxiv` to fetch new papers, hands off to a “Math Interpreter” agent running on a local GPT‑OSS model for LaTeX reasoning via `arxiv-latex-mcp`, then passes the distilled notes to an “Obsidian Archivist” agent that writes them into the vault using `obsidian-mcp`. The Agents SDK can encode this pipeline in a maintainable, declarative fashion, complete with tracing for debugging and auditability.
+
+### python‑sdk
+
+This repository contains the Python implementation of the Model Context Protocol, providing both the core `mcp` library and development tools. It exposes abstractions for servers, resources, tools, prompts, and more. For our purposes, the Python SDK is the most direct route to building custom MCP servers that run inside the codex-universal environment.
+
+A straightforward application would be to create a bespoke “Vector Index” MCP server that wraps an embeddings store. Agents could then query semantic neighborhoods of Obsidian notes or arXiv papers. Because the SDK supports structured output and authentication, such a server could also enforce policies around note access, enabling multi‑agent collaboration without compromising privacy.
+
+### modelcontextprotocol
+
+The `modelcontextprotocol` repository holds the specification, schema, and official documentation for MCP. It is the canonical reference for how servers and clients communicate. Beyond serving as documentation, the schema files can be used to auto‑generate types in various languages, ensuring that custom servers conform to the protocol.
+
+Studying the spec is essential before extending the system with novel capabilities—be it a CrossRef bibliographic server, a GitHub issue triaging tool, or a homelab telemetry feed. By adhering to MCP’s design, each new component becomes immediately accessible to any compatible client, from Codex CLI to future agent hosts.
+
+### servers
+
+The `servers` repo is a showcase of reference implementations for MCP servers, including file system access, Git interaction, time and timezone tools, a “memory” knowledge graph, and an “everything” server used for testing. These implementations serve as blueprints for building domain‑specific servers. For instance, the `git` server demonstrates how to safely expose repository operations; adapting it for the user’s work could allow an agent to fetch commit histories, generate changelogs, or triage merge conflicts.
+
+The presence of a `memory` server is particularly relevant to the knowledge base vision. It implements a persistent knowledge graph that agents can read and write, offering a structured alternative to free‑form note taking. Incorporating a similar memory layer alongside Obsidian could yield a hybrid system where narrative notes and structured facts coexist.
+
+### quickstart‑resources
+
+This repository gathers tutorial code for MCP, including a simple weather server and client implementations in Python and TypeScript. Its primary value is pedagogical: it lowers the barrier for new agents to experiment with MCP, ensuring that future contributors—human or AI—can extend the system without steep learning curves. It also serves as a template for writing well‑documented, easily deployable servers, a pattern worth emulating when authoring custom connectors.
+
+### github‑mcp‑server
+
+The GitHub MCP Server connects AI agents directly to GitHub, enabling repository browsing, issue and pull request management, and workflow monitoring through natural language. In the context of this workspace, it allows an agent to maintain the very repository that defines it. A Codex CLI instance could, for example, use the GitHub server to open pull requests for new Obsidian notes or to synchronize fine‑tuned models via GitHub Releases.
+
+Security considerations are paramount here. Because the server can manipulate repositories, it should be configured with scoped tokens and perhaps restricted to read‑only mode for most agents. Nonetheless, its presence hints at a future where agents manage not just code but the meta‑processes of development—CI pipelines, issue triage, or documentation updates—without direct human intervention.
+
+### openai‑cookbook
+
+The OpenAI Cookbook is a compendium of example code and guides for the OpenAI API. While ostensibly a learning resource, in this ecosystem it acts as a quick reference for advanced patterns—streaming responses, function calling, embeddings, and more. Agents can pull snippets on demand to bootstrap new capabilities. For instance, an agent tasked with implementing a PDF summarizer could extract relevant code from the cookbook, adapt it to the current repo’s style, and run tests—all automatically.
+
+A creative extension would be to index the cookbook examples into the knowledge base, tagging each with the APIs or techniques it demonstrates. Then, when a future agent faces a novel task, it can query this index to retrieve the most relevant example before writing any code.
+
+### mcp‑obsidian
+
+This repository supplies an MCP connector that allows clients like Claude Desktop to read and search directories of Markdown notes, targeting Obsidian vaults. It primarily supports read‑only operations but excels at providing quick context access. For the knowledge management goals, mcp‑obsidian is the lightweight bridge between the agent ecosystem and the user’s curated notes.
+
+Imagine a daily workflow where Codex CLI acts as a “morning brief” agent: it uses mcp‑obsidian to scan recent notes for open questions, cross‑references them with `mcp-simple-arxiv` to find new papers, and produces a prioritized research agenda. Because the connector is read‑only, it poses minimal risk to the vault while offering substantial utility.
+
+### obsidian‑mcp
+
+Complementing mcp‑obsidian, the `obsidian-mcp` server offers read and write access to Obsidian vaults, including tag management and note creation. While more powerful, it requires careful safeguards—backups, commit hooks, or sandboxed branches—to prevent accidental data loss. Its real strength lies in enabling automated curation: agents can draft literature summaries, embed backlinks, or reorganize notes based on emerging themes.
+
+One could configure an agent that monitors the arXiv feed for new papers, summarizes them, and uses obsidian-mcp to file each summary into the vault with proper tags and links. Combined with the GitHub MCP server, these commits could be pushed to a remote repository, creating an ever‑growing, version‑controlled knowledge base.
+
+### arxiv‑latex‑mcp
+
+This server fetches LaTeX source from arXiv and exposes it to MCP clients. By working at the source level, it preserves mathematical notation and equations that often get mangled in PDFs. For technical domains where precise symbol manipulation matters, this is indispensable. In the envisioned knowledge pipeline, an agent would use arxiv-latex-mcp to obtain the LaTeX of a new paper, parse the sections, and generate structured notes or even executable proofs.
+
+A future enhancement could integrate this server with a symbolic math engine, allowing agents to verify derivations or generate alternative formulations of theorems, thereby turning passive reading into active mathematical exploration.
+
+### mcp‑simple‑arxiv
+
+`mcp-simple-arxiv` is a lighter connector that interacts with the arXiv API, returning paper metadata, abstracts, and links to PDFs or HTML versions. It is ideal for initial triage: agents can query by keyword, retrieve candidate papers, and decide which ones warrant deeper processing via `arxiv-latex-mcp` or `arxiv-mcp-server`.
+
+Because the server can run in HTTP mode, it can also serve remote agents across the WireGuard network. For example, a Raspberry Pi could host a minimal `mcp-simple-arxiv` instance that the homelab queries periodically, reducing load on the main servers.
+
+### arxiv‑mcp‑server
+
+This implementation emphasizes search and local caching of papers. It can download PDFs, maintain a listing of retrieved documents, and provides a set of research prompts. By storing papers locally, it accelerates repeated access and enables offline workflows. Within the knowledge base vision, arxiv-mcp-server could act as the archival layer: once a paper is deemed relevant, it is fetched and stored, then annotated in Obsidian with backlinks to the local cache.
+
+A compelling extension would be to integrate the server with an embeddings index so that agents can perform semantic search across previously downloaded papers, enabling literature reviews that build on past work rather than starting from scratch each time.
+
+## Synthesis and Strategic Applications
+
+The repositories above cluster into five functional domains: **agent orchestration**, **model hosting and fine‑tuning**, **knowledge ingestion**, **knowledge storage**, and **infrastructure parity**. By weaving them together we can construct robust workflows that advance the project’s immediate and long‑term goals.
+
+1. **Agent Orchestration** – `codex`, `openai-agents-python`, and `agents.md` provide the scaffolding for multi‑agent systems that respect shared instructions. Through MCP, these agents can invoke specialized servers, transfer control via handoffs, and maintain audit trails.
+2. **Model Hosting and Fine‑Tuning** – `gpt-oss`, `llama.cpp`, and `unsloth` empower the homelab to host capable models offline and tailor them to the user’s corpus. Harmony ensures responses remain interoperable with cloud models.
+3. **Knowledge Ingestion** – `mcp-simple-arxiv`, `arxiv-latex-mcp`, and `arxiv-mcp-server` provide multiple levels of fidelity for acquiring scientific literature, from quick metadata fetches to full LaTeX source retrieval.
+4. **Knowledge Storage and Retrieval** – `mcp-obsidian` and `obsidian-mcp` interface with the user’s vault, while `servers/memory` and potential custom vector stores offer structured alternatives.
+5. **Infrastructure Parity** – `codex-universal`, `modelcontextprotocol`, `python-sdk`, `quickstart-resources`, and `openai-cookbook` ensure that every environment—from cloud to homelab—shares a common operational and educational baseline.
+
+With these domains aligned, several concrete workflows emerge:
+
+- **Automated Research Digest**: A scheduled agent uses `mcp-simple-arxiv` to scan for new papers matching topics of interest. Promising candidates are fetched via `arxiv-latex-mcp` for equation‑aware parsing. Summaries are generated by a GPT‑OSS model fine‑tuned with `unsloth` on past notes, then committed to Obsidian via `obsidian-mcp`. Codex CLI orchestrates the process, and results are archived with `arxiv-mcp-server` for offline access.
+
+- **Cross‑Model Code Assistant**: When coding tasks arise, an agent in Codex Cloud coordinates with a homelab counterpart. The cloud agent leverages GPT‑5 for reasoning and broad knowledge, while the local agent uses llama.cpp‑hosted GPT‑OSS for high‑throughput code generation. Both share Harmony‑formatted transcripts, and the final patch is reviewed through the GitHub MCP server before being pushed.
+
+- **Distributed Knowledge Graph**: The `servers/memory` reference can be expanded into a global graph where nodes represent papers, notes, code snippets, and model checkpoints. Agents update the graph as they work, and specialized queries surface connections that might otherwise remain hidden—e.g., two papers proving similar lemmas with different notation.
+
+## Future Directions and Creative Leaps
+
+1. **Semantic WireGuard Mesh** – Extend MCP over the WireGuard network so that each homelab node exposes its capabilities as discoverable services. A Pi running a sensor MCP could provide real‑time telemetry, while a GPU box offers GPT‑OSS inference. Codex CLI could maintain a registry, routing tasks to the most appropriate node.
+
+2. **Transclusion‑Aware Obsidian Agent** – Build an agent that understands Obsidian’s transclusion syntax (`![[note]]`). When summarizing a paper, it could automatically link to prerequisite concepts, creating a web of interconnected notes. With `obsidian-mcp`, it could even generate diagrams or export parts of the vault as a Quartz site.
+
+3. **Adaptive Model Selection** – Implement a policy engine that chooses between GPT‑5 and GPT‑OSS based on task complexity, cost, and latency. Simple factual queries use a local model; intricate reasoning or speculative design escalates to GPT‑5. Harmony makes this switching transparent to higher‑level workflows.
+
+4. **Embeddings Everywhere** – Using code from the OpenAI Cookbook, create an embeddings service that indexes not only papers and notes but also the code in this repository and the reference repos. Agents could then perform semantic searches across the entire corpus, bridging research, implementation, and documentation.
+
+5. **Agent Identity Federation** – Leverage GitHub MCP and Agents SDK handoffs to allow different model instances to operate under distinct GitHub personas. One account could specialize in academic curation, another in code maintenance, each with scoped permissions and tailored instructions in their respective `AGENTS.md` files. A central coordinator agent would reconcile their outputs.
+
+6. **Autonomous Fine‑Tuning Loops** – Combine `unsloth`, `arxiv-mcp-server`, and the knowledge graph to create a self‑improving model. When the system ingests a batch of papers on a new topic, it spins up an unsloth job to fine‑tune GPT‑OSS, evaluates the model against a suite of tasks using the Agents SDK, and promotes it to production if it outperforms the previous version.
+
+7. **MCP‑Native Citation Style** – Develop a tool that converts MCP interaction logs into citation‑ready references. When agents produce reports (including this one), they can automatically append a bibliography of papers, repos, and tools involved, ensuring human‑readable provenance.
+
+8. **Cross‑Platform IDE Integration** – Use the GitHub MCP server in conjunction with `codex` to implement IDE plugins that surface context from the knowledge base as developers work. Type a function name, and the plugin fetches related notes from Obsidian, relevant cookbook examples, and past code snippets via the memory server.
+
+9. **Privacy‑Preserving Collaboration** – Employ the python‑sdk to create MCP proxies that redact sensitive data when interfacing with cloud agents. For example, an agent could query the Obsidian vault through a proxy that strips personal identifiers, allowing GPT‑5 to assist without exposing private content.
+
+10. **Living Documentation Generator** – Periodically run an agent that scans all reference repos for updates—new functions in `openai-agents-python`, new tutorials in the cookbook, changes to the MCP spec—and integrates the highlights into this report. Over time the document becomes a chronicle of the evolving ecosystem, maintained collaboratively by humans and agents.
+
+## Conclusion
+
+The reference repositories assembled here form a toolkit for building a distributed, resilient, and intelligent knowledge infrastructure. By standardizing environments through `codex-universal`, orchestrating agents with `codex` and the Agents SDK, hosting adaptable models via `gpt-oss`, and wiring in knowledge sources like arXiv and Obsidian, the system positions itself to grow organically. The suggestions outlined—from semantic meshes to autonomous fine‑tuning—are starting points for exploration. Each leverages the existing repositories while pointing toward new ones, keeping the spirit of `AGENTS.md` alive: a living manual for the agents themselves.
+


### PR DESCRIPTION
## Summary
- add 3500-word analysis of hydrated reference repositories with strategic integration ideas

## Testing
- `bash scripts/container-maintenance.sh`


------
https://chatgpt.com/codex/tasks/task_b_68b2b70b74f8832e870ddc6f8d07495e