### PR TITLE
Install GitHub CLI and configure token auth

### DIFF
--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -7,7 +7,7 @@ if ! command -v gh >/dev/null 2>&1; then
   apt-get update -y && apt-get install -y gh
 fi
 if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
-  echo "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1 || true
+  gh auth login --with-token < <(echo "$GH_TOKEN") >/dev/null 2>&1 || true
 fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 echo "[setup] start"
 if ! command -v git >/dev/null 2>&1; then apt-get update -y && apt-get install -y git; fi
 if ! command -v curl >/dev/null 2>&1; then apt-get update -y && apt-get install -y curl; fi
+if ! command -v gh >/dev/null 2>&1; then
+  apt-get update -y && apt-get install -y gh
+fi
+if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+  echo "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1 || true
+fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 fi


### PR DESCRIPTION
## Summary
- Install GitHub CLI during container setup
- Automatically authenticate gh using GH_TOKEN when available

## Testing
- `bash scripts/container-setup.sh`
- `gh auth status`


------
https://chatgpt.com/codex/tasks/task_b_68b2c0276c98832e89170ed8ab623612