### PR TITLE
Install and document GitHub CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repo is the shared workspace for local and cloud agents. Heavy reference re
 - Image: `openai/codex-universal` (Ubuntu 24.04; Python/Node/Rust/Go/Ruby/etc. preinstalled)
 - Internet: enabled
 - Env vars: expects `OPENAI_API_KEY` at runtime (do **not** commit secrets)
+- GitHub CLI: preinstalled and authenticated via `GH_TOKEN` for read-only GitHub access
 - Container caching: on
 - Setup script: `bash scripts/container-setup.sh`
 - Maintenance script: `bash scripts/container-maintenance.sh`

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -3,6 +3,20 @@ set -euo pipefail
 echo "[setup] start"
 if ! command -v git >/dev/null 2>&1; then apt-get update -y && apt-get install -y git; fi
 if ! command -v curl >/dev/null 2>&1; then apt-get update -y && apt-get install -y curl; fi
+if ! command -v gh >/dev/null 2>&1; then
+  apt-get update -y
+  apt-get install -y curl apt-transport-https ca-certificates gnupg
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -y
+  apt-get install -y gh
+fi
+if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+  gh auth login --with-token < <(printf '%s' "$GH_TOKEN") >/dev/null 2>&1 || true
+fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 fi


### PR DESCRIPTION
## Summary
- install GitHub CLI from official repository when missing and authenticate with `GH_TOKEN`
- note in `AGENTS.md` that the environment ships with an authenticated GitHub CLI for read-only access

## Testing
- `bash scripts/container-setup.sh`
- `gh auth status`


------
https://chatgpt.com/codex/tasks/task_b_68b2c0276c98832e89170ed8ab623612