### PR TITLE
Install GitHub CLI and configure token auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repo is the shared workspace for local and cloud agents. Heavy reference re
 - Image: `openai/codex-universal` (Ubuntu 24.04; Python/Node/Rust/Go/Ruby/etc. preinstalled)
 - Internet: enabled
 - Env vars: expects `OPENAI_API_KEY` at runtime (do **not** commit secrets)
+- GitHub CLI: preinstalled and authenticated via `GH_TOKEN` for read-only GitHub access
 - Container caching: on
 - Setup script: `bash scripts/container-setup.sh`
 - Maintenance script: `bash scripts/container-maintenance.sh`

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -16,10 +16,16 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
   tmpfile="$(mktemp)"
+  trap 'rm -f "$tmpfile"' EXIT
   chmod 600 "$tmpfile"
   printf '%s' "$GH_TOKEN" >"$tmpfile"
-  gh auth login --with-token <"$tmpfile" >/dev/null 2>&1 || true
+  if gh auth login --with-token <"$tmpfile" >/dev/null 2>&1; then
+    echo "[setup] GitHub CLI authenticated successfully."
+  else
+    echo "[setup] WARNING: GitHub CLI authentication failed. Continuing without authentication." >&2
+  fi
   rm -f "$tmpfile"
+  trap - EXIT
 fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -3,6 +3,24 @@ set -euo pipefail
 echo "[setup] start"
 if ! command -v git >/dev/null 2>&1; then apt-get update -y && apt-get install -y git; fi
 if ! command -v curl >/dev/null 2>&1; then apt-get update -y && apt-get install -y curl; fi
+if ! command -v gh >/dev/null 2>&1; then
+  apt-get update -y
+  apt-get install -y apt-transport-https ca-certificates gnupg
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -y
+  apt-get install -y gh
+fi
+if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+  tmpfile="$(mktemp)"
+  chmod 600 "$tmpfile"
+  printf '%s' "$GH_TOKEN" >"$tmpfile"
+  gh auth login --with-token <"$tmpfile" >/dev/null 2>&1 || true
+  rm -f "$tmpfile"
+fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 fi


### PR DESCRIPTION
## Summary
- install GitHub CLI from official apt repository if missing
- authenticate GitHub CLI using GH_TOKEN via secure temp file
- document GitHub CLI availability in AGENTS

## Testing
- `GH_TOKEN=dummy bash scripts/container-setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_68b3f89163f4832e8cf1ad6c03ae0013