### PR TITLE
Disable gh pager in setup

### DIFF
--- a/docs/codex-environment.md
+++ b/docs/codex-environment.md
@@ -6,6 +6,7 @@
 
 ## Environment variables
 - `OPENAI_API_KEY`: required for any OpenAI-compatible clients run inside the container.
+- `GH_TOKEN`: preloaded token for the GitHub CLI; the setup script authenticates using this token and disables paging to avoid hangs in non-interactive sessions.
 
 ## Setup script (runs on cold container after repo clone)
 ```bash

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -27,6 +27,10 @@ if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
   rm -f "$tmpfile"
   trap - EXIT
 fi
+# Disable gh paging to avoid hanging in non-interactive sessions
+if command -v gh >/dev/null 2>&1; then
+  gh config set pager cat >/dev/null 2>&1 || true
+fi
 if ! command -v yq >/dev/null 2>&1; then
   curl -sSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 fi


### PR DESCRIPTION
## Summary
- configure `gh` to disable paging so commands don't hang
- document `GH_TOKEN` usage and pager behavior in environment notes

## Testing
- `bash -n scripts/container-setup.sh`
- `gh repo list S-Ali-Zaidi --limit 5`

------
https://chatgpt.com/codex/tasks/task_b_68b4093ca61c832eaeba834773617131