### PR TITLE
Normalize GitHub token environment variable names for gh setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repo is the shared workspace for local and cloud agents. Heavy reference re
 - Image: `openai/codex-universal` (Ubuntu 24.04; Python/Node/Rust/Go/Ruby/etc. preinstalled)
 - Internet: enabled
 - Env vars: expects `OPENAI_API_KEY` at runtime (do **not** commit secrets)
-- GitHub CLI: preinstalled and authenticated via `GH_TOKEN` for read-only GitHub access
+- GitHub CLI: preinstalled and authenticated via `GH_TOKEN`/`GITHUB_TOKEN`/`GH_Token` for read-only GitHub access
 - Container caching: on
 - Setup script: `bash scripts/container-setup.sh`
 - Maintenance script: `bash scripts/container-maintenance.sh`

--- a/docs/codex-environment.md
+++ b/docs/codex-environment.md
@@ -6,6 +6,7 @@
 
 ## Environment variables
 - `OPENAI_API_KEY`: required for any OpenAI-compatible clients run inside the container.
+- `GH_TOKEN` / `GITHUB_TOKEN` / `GH_Token`: any of these names may supply the GitHub token that authenticates the preinstalled `gh` CLI.
 
 ## Setup script (runs on cold container after repo clone)
 ```bash

--- a/scripts/container-setup.sh
+++ b/scripts/container-setup.sh
@@ -14,11 +14,12 @@ if ! command -v gh >/dev/null 2>&1; then
   apt-get update -y
   apt-get install -y gh
 fi
-if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+GH_TOKEN_ENV="${GH_TOKEN:-${GITHUB_TOKEN:-${GH_Token:-}}}"
+if command -v gh >/dev/null 2>&1 && [ -n "$GH_TOKEN_ENV" ]; then
   tmpfile="$(mktemp)"
   trap 'rm -f "$tmpfile"' EXIT
   chmod 600 "$tmpfile"
-  printf '%s' "$GH_TOKEN" >"$tmpfile"
+  printf '%s' "$GH_TOKEN_ENV" >"$tmpfile"
   if gh auth login --with-token <"$tmpfile" >/dev/null 2>&1; then
     echo "[setup] GitHub CLI authenticated successfully."
   else


### PR DESCRIPTION
## Summary
- allow the container setup script to authenticate GitHub CLI with GH_TOKEN, GITHUB_TOKEN, or GH_Token
- document the accepted GitHub token variable names in the environment guide and agent instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c83ccf4ee8832eb93d903c441d725a